### PR TITLE
Fix database fallback reset and enable async tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -208,6 +208,12 @@ class DatabaseManager:
         self.users = {}
         self.conversations = []
         self.ai_memory = {}
+        # Ensure task-related collections also fall back to in-memory
+        # storage when MongoDB isn't available. Without resetting these
+        # attributes, parts of the code might continue using a stale
+        # MongoDB collection reference which would lead to runtime errors.
+        self.tasks = {}
+        self.tasks_collection = None
 
     def _create_indexes(self):
         """Create database indexes for better performance"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pymongo==4.6.1
 python-dotenv==1.0.0
 requests==2.31.0
 pytest>=7.0.0
+pytest-asyncio>=0.21

--- a/test_database_manager.py
+++ b/test_database_manager.py
@@ -1,0 +1,28 @@
+import sys
+import types
+
+
+def test_fallback_resets_task_collections():
+    # main.py requires 'intelligent_maya' which isn't available in tests.
+    # Provide a lightweight stub so we can import DatabaseManager without
+    # pulling in the full dependency graph.
+    dummy = types.ModuleType("intelligent_maya")
+    dummy.IntelligentMayaAgent = object
+    dummy.init_intelligent_maya = lambda *args, **kwargs: None
+    dummy.intelligent_maya = None
+    dummy.smart_response = None
+    sys.modules.setdefault("intelligent_maya", dummy)
+
+    from main import DatabaseManager
+
+    db = DatabaseManager()
+    # Simulate that the database was previously connected and holds
+    # task-related state
+    db.tasks = {"dummy": {"id": "1"}}
+    db.tasks_collection = object()
+
+    # Trigger fallback to in-memory storage
+    db._setup_fallback_storage()
+
+    assert db.tasks == {}
+    assert db.tasks_collection is None

--- a/test_maya_integration.py
+++ b/test_maya_integration.py
@@ -7,6 +7,7 @@ Tests the integration of IntelligentMayaAgent with fallbacks
 
 import asyncio
 import os
+import pytest
 from dotenv import load_dotenv
 
 # Load environment variables
@@ -64,6 +65,7 @@ def test_bot_initialization():
         print(f"❌ Bot initialization failed: {e}")
         return False
 
+@pytest.mark.asyncio
 async def test_simple_gemini():
     """Test simple Gemini API call"""
     print("\n🔍 Testing simple Gemini API call...")
@@ -91,6 +93,7 @@ async def test_simple_gemini():
         print(f"❌ Gemini API test failed: {e}")
         return False
 
+@pytest.mark.asyncio
 async def test_traditional_ai():
     """Test traditional AI system"""
     print("\n🔍 Testing traditional AI system...")
@@ -121,6 +124,7 @@ async def test_traditional_ai():
         print(f"❌ Traditional AI test failed: {e}")
         return False
 
+@pytest.mark.asyncio
 async def test_message_handling():
     """Test complete message handling flow"""
     print("\n🔍 Testing complete message handling...")


### PR DESCRIPTION
## Summary
- ensure DatabaseManager resets task collections when falling back to in-memory storage
- enable async integration tests by adding pytest-asyncio and appropriate markers
- add regression test covering fallback behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac14ffdee08321bbc07e284032484a