### PR TITLE
Fix database fallback reset and handle optional intelligent_maya

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,7 +41,23 @@ from pymongo import MongoClient
 from pymongo.errors import ConnectionFailure
 
 # Intelligent Maya Agent
-from intelligent_maya import IntelligentMayaAgent, init_intelligent_maya, intelligent_maya, smart_response
+try:
+    from intelligent_maya import (
+        IntelligentMayaAgent,
+        init_intelligent_maya,
+        intelligent_maya,
+        smart_response,
+    )
+    INTELLIGENT_MAYA_AVAILABLE = True
+except ModuleNotFoundError:
+    IntelligentMayaAgent = None
+    intelligent_maya = None
+    smart_response = None
+
+    def init_intelligent_maya(*args, **kwargs):  # type: ignore
+        return None
+
+    INTELLIGENT_MAYA_AVAILABLE = False
 
 # ============================
 # CONFIGURATION & SETUP
@@ -208,6 +224,12 @@ class DatabaseManager:
         self.users = {}
         self.conversations = []
         self.ai_memory = {}
+        # Ensure task-related collections also fall back to in-memory
+        # storage when MongoDB isn't available. Without resetting these
+        # attributes, parts of the code might continue using a stale
+        # MongoDB collection reference which would lead to runtime errors.
+        self.tasks = {}
+        self.tasks_collection = None
 
     def _create_indexes(self):
         """Create database indexes for better performance"""
@@ -1058,13 +1080,15 @@ class MayaBot:
         # Initialize database first
         self.db = DatabaseManager()
         
-        # Initialize intelligent Maya agent if Gemini API key is available
-        if GEMINI_API_KEY:
+        # Initialize intelligent Maya agent if available
+        if GEMINI_API_KEY and INTELLIGENT_MAYA_AVAILABLE:
             self.intelligent_agent = init_intelligent_maya(GEMINI_API_KEY)
             logger.info("✅ IntelligentMayaAgent initialized successfully")
         else:
             self.intelligent_agent = None
-            logger.warning("⚠️ No Gemini API key - IntelligentMayaAgent disabled")
+            logger.warning(
+                "⚠️ IntelligentMayaAgent disabled - missing module or API key"
+            )
             
         # Keep the traditional AI as backup
         self.ai = MayaAI()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pymongo==4.6.1
 python-dotenv==1.0.0
 requests==2.31.0
 pytest>=7.0.0
+pytest-asyncio>=0.21

--- a/test_database_manager.py
+++ b/test_database_manager.py
@@ -1,0 +1,28 @@
+import sys
+import types
+
+
+def test_fallback_resets_task_collections():
+    # main.py requires 'intelligent_maya' which isn't available in tests.
+    # Provide a lightweight stub so we can import DatabaseManager without
+    # pulling in the full dependency graph.
+    dummy = types.ModuleType("intelligent_maya")
+    dummy.IntelligentMayaAgent = object
+    dummy.init_intelligent_maya = lambda *args, **kwargs: None
+    dummy.intelligent_maya = None
+    dummy.smart_response = None
+    sys.modules.setdefault("intelligent_maya", dummy)
+
+    from main import DatabaseManager
+
+    db = DatabaseManager()
+    # Simulate that the database was previously connected and holds
+    # task-related state
+    db.tasks = {"dummy": {"id": "1"}}
+    db.tasks_collection = object()
+
+    # Trigger fallback to in-memory storage
+    db._setup_fallback_storage()
+
+    assert db.tasks == {}
+    assert db.tasks_collection is None

--- a/test_main_without_intelligent_maya.py
+++ b/test_main_without_intelligent_maya.py
@@ -1,0 +1,23 @@
+import sys
+import importlib
+import builtins
+
+
+def test_main_import_without_intelligent_maya(monkeypatch):
+    # Ensure 'intelligent_maya' is not importable
+    sys.modules.pop('intelligent_maya', None)
+    sys.modules.pop('main', None)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'intelligent_maya':
+            raise ModuleNotFoundError
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+
+    main = importlib.import_module('main')
+    assert main.INTELLIGENT_MAYA_AVAILABLE is False
+    bot = main.MayaBot()
+    assert bot.intelligent_agent is None

--- a/test_maya_integration.py
+++ b/test_maya_integration.py
@@ -7,6 +7,7 @@ Tests the integration of IntelligentMayaAgent with fallbacks
 
 import asyncio
 import os
+import pytest
 from dotenv import load_dotenv
 
 # Load environment variables
@@ -64,6 +65,7 @@ def test_bot_initialization():
         print(f"❌ Bot initialization failed: {e}")
         return False
 
+@pytest.mark.asyncio
 async def test_simple_gemini():
     """Test simple Gemini API call"""
     print("\n🔍 Testing simple Gemini API call...")
@@ -91,6 +93,7 @@ async def test_simple_gemini():
         print(f"❌ Gemini API test failed: {e}")
         return False
 
+@pytest.mark.asyncio
 async def test_traditional_ai():
     """Test traditional AI system"""
     print("\n🔍 Testing traditional AI system...")
@@ -121,6 +124,7 @@ async def test_traditional_ai():
         print(f"❌ Traditional AI test failed: {e}")
         return False
 
+@pytest.mark.asyncio
 async def test_message_handling():
     """Test complete message handling flow"""
     print("\n🔍 Testing complete message handling...")


### PR DESCRIPTION
## Summary
- ensure DatabaseManager resets task collections when falling back to in-memory storage
- enable async integration tests by adding pytest-asyncio and appropriate markers
- gracefully handle missing `intelligent_maya` dependency and log when disabled
- add regression tests covering fallback behaviour and missing dependency handling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac14ffdee08321bbc07e284032484a